### PR TITLE
Add Docker Compose for easy setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+- Initial Docker support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Node LTS image
+FROM node:16-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package.json package-lock.json* ./
+RUN npm install && npm cache clean --force
+
+# Copy source
+COPY . .
+
+# Expose default port used by gulp connect
+EXPOSE 8080
+
+# Default command serves the project
+CMD ["npx", "gulp", "serve"]

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,3 @@
+# Issues Log
+
+- [ ] Automated tests fail due to PhantomJS dependency not installing on modern Node. Requires dependency updates.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+# TODO
+
+- [x] Add Dockerfile and docker-compose to run the project.
+- [ ] Review outdated dependencies and modernize the build.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app
+    command: ["npx", "gulp", "serve"]

--- a/readme.md
+++ b/readme.md
@@ -107,3 +107,12 @@ Pushez la branche :
 Créez une Pull Request
 
 Version : v-0.0.1
+## Docker Compose
+
+Pour construire et lancer le lecteur avec Docker Compose :
+
+```bash
+docker compose up --build
+```
+
+Puis accédez à `http://localhost:8080/examples/index.html`.


### PR DESCRIPTION
## Summary
- add Dockerfile for container build
- add docker-compose.yml for running via Docker Compose
- document usage in readme
- add basic CHANGELOG, TODO, and ISSUES logs

## Testing
- `npm install` *(fails: PhantomJS not found)*
- `npx gulp test` *(prompted for installing gulp, hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68502915efa083239add4a31a4e83bb5