### PR TITLE
Add build failure test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Initial Docker support.
+- Added build test script to reproduce npm install failure on modern Node.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,3 +1,4 @@
 # Issues Log
 
 - [ ] Automated tests fail due to PhantomJS dependency not installing on modern Node. Requires dependency updates.
+- [ ] node-sass build fails on Node 16+ preventing `npm install`. Needs replacement with maintained sass implementation.

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,5 @@
 
 - [x] Add Dockerfile and docker-compose to run the project.
 - [ ] Review outdated dependencies and modernize the build.
+- [x] Create test script to reproduce build failure.
+- [ ] Update dependencies to resolve build failure.

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "lodash": "^2.4.1"
+  },
+  "scripts": {
+    "test": "node tests/build.js"
   }
 }

--- a/tests/build.js
+++ b/tests/build.js
@@ -1,0 +1,9 @@
+const { execSync } = require('child_process');
+
+try {
+  execSync('npm install', { stdio: 'inherit' });
+  console.log('npm install succeeded.');
+} catch (err) {
+  console.error('npm install failed.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add test script that runs `npm install` to surface build failures
- hook test script to `npm test`
- log new issue about node-sass incompatibility
- update changelog and TODO

## Testing
- `npm test` *(fails: node-sass / phantomjs build issues)*

------
https://chatgpt.com/codex/tasks/task_e_685047f0e1848323a16846d321277e09